### PR TITLE
Fix Sticky Header Obscuring Window-Size Player

### DIFF
--- a/src/styles/content.scss
+++ b/src/styles/content.scss
@@ -27,7 +27,7 @@ html.enhancer-fullVideo.page-video {
     margin-top: 0 !important;
   }
 
-  #NebulaApp > div:first-of-type {
+  #app-header {
     position: absolute !important;
     top: 100vh !important;
   }


### PR DESCRIPTION
Updated header selector as the header is not moved to below the player, obscuring the player when expand-to-window-size is enabled.

In fairness I did not fully build and test on my end, just with dev tools.